### PR TITLE
format-json filter now handles utf-8 correctly

### DIFF
--- a/lib/urlwatch/filters.py
+++ b/lib/urlwatch/filters.py
@@ -196,7 +196,7 @@ class JsonFormatFilter(FilterBase):
         if subfilter is not None:
             indentation = int(subfilter)
         parsed_json = json.loads(data)
-        return json.dumps(parsed_json, sort_keys=True, indent=indentation, separators=(',', ': '))
+        return json.dumps(parsed_json, ensure_ascii=False, sort_keys=True, indent=indentation, separators=(',', ': '))
 
 
 class GrepFilter(FilterBase):


### PR DESCRIPTION
Currently the filter outputs non-ASCII characters as escaped (e.g. '–' is replaced by '\u2013') which makes some text very hard to read.  It is due to the fact that the json.dumps function defaults the ensure_ascii setting to True; setting it to False fixes the issue. Documentation: https://docs.python.org/3/library/json.html#json.dump